### PR TITLE
chore: Add list of CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,21 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @darmawanalbert @cakraocha @nuvianggaresti @wildananugra @clawrencia
+
+# Owners for specific domain
+/.github/ @darmawanalbert
+/.vscode/ @darmawanalbert
+/architectures/ @wildananugra
+/classifier/ @clawrencia
+/database/ @cakraocha
+/frontend/ @darmawanalbert
+/harvesters/ @clawrencia
+/keypairs/ @wildananugra
+/nginx/ @wildananugra
+/services/ @nuvianggaresti
+/templates/ @wildananugra


### PR DESCRIPTION
Since we are enforcing code reviews and CI/CD, it would be great if we use [CODEOWNERS](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) feature.

For example, if anyone willingly/accidentally change harvesters, then @clawrencia needs to know and ensure that the changes are fine.