### PR TITLE
fix: Incorrect global codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,6 @@
 # This is a comment.
 # Each line is a file pattern followed by one or more owners.
 
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
-*       @darmawanalbert @cakraocha @nuvianggaresti @wildananugra @clawrencia
-
 # Owners for specific domain
 /.github/ @darmawanalbert
 /.vscode/ @darmawanalbert


### PR DESCRIPTION
I thought the global codeowners setting used disjunction, but apparently it is conjunction. My bad